### PR TITLE
Fix git_pre_commit.sh not passing '--style-file' argument to clang-format

### DIFF
--- a/scripts/git_hooks/git_pre_commit.sh
+++ b/scripts/git_hooks/git_pre_commit.sh
@@ -59,7 +59,7 @@ fi
 
 log_action "Checking formatting of staged changes"
 if [[ -n "$STAGED_C_FILES" || -n "$STAGED_HEADER_FILES" ]]; then
-  clang-format --dry-run -Werror $STAGED_C_FILES $STAGED_HEADER_FILES || abort_action_pipeline
+  clang-format --style=file --dry-run -Werror $STAGED_C_FILES $STAGED_HEADER_FILES || abort_action_pipeline
 fi
 if [[ -n "$STAGED_LUA_FILES" ]]; then
   stylua --check $STAGED_LUA_FILES 1>&2 || abort_action_pipeline


### PR DESCRIPTION
clang-format docs state that this argument must be present to search for .clang-format config file. Wasn't caught earlier due to my clang-format v18.1.8 already doing this by default (docs/implementation discrepancy?).