### PR TITLE
Update REPL history to be persistent across sessions

### DIFF
--- a/include/utils/str.h
+++ b/include/utils/str.h
@@ -23,4 +23,17 @@ inline bool str_is_all_whitespace(char const *string) {
   return true;
 }
 
+/**@desc count number of newlines within a `string`
+@return newline count*/
+inline size_t str_count_lines(char const *string) {
+  assert(string != NULL);
+
+  size_t line_count = 0;
+  for (; *string != '\0'; ++string) {
+    if (*string == '\n') line_count++;
+  }
+
+  return line_count;
+}
+
 #endif // STR_H

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -5,3 +5,4 @@
 // *---------------------------------------------*
 
 bool str_is_all_whitespace(char const *string);
+size_t str_count_lines(char const *string);


### PR DESCRIPTION
Update REPL history to make it persistent across sessions through external storage (filesystem) usage.
Currently only compatible with POSIX systems.